### PR TITLE
Give list objects their own key.

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,8 +61,10 @@ $(document).ready(function() {
 });
 
 
-var List = function () {
+var List = function (localStorageKey) {
     var self = this
+
+    self.localStorageKey = localStorageKey;
     
     self.listItems = [];
 
@@ -76,6 +78,7 @@ var List = function () {
             
         }
         //return this.listItems;
+        self.storeList();
         return false;
     };
     
@@ -91,20 +94,20 @@ var List = function () {
         if (indexOfItem != -1) {
             self.listItems.splice(indexOfItem, 1);
         }
-        
+        self.storeList();
     };
     
     self.storeList = function() {
             var myList = JSON.stringify(self.listItems);
-            localStorage.setItem("myList", myList);
+            localStorage.setItem(self.localStorageKey, myList);
         };
         
     self.retrieveList = function() {
-        self.listItems = JSON.parse(localStorage.getItem("myList"));
+        self.listItems = JSON.parse(localStorage.getItem(self.localStorageKey));
         };
 
 };
         
     
 
-var todoList = new List();
+var todoList = new List('todoList');

--- a/app.js
+++ b/app.js
@@ -39,8 +39,7 @@ $(document).ready(function() {
     
     $('#list').sortable();
     
-    if(localStorage.getItem('myList')) {
-        todoList.retrieveList();
+    if (todoList.retrieveList()) {
         todoList.generateListDiv($('#list'));
     }
     
@@ -101,7 +100,13 @@ var List = function (localStorageKey) {
         };
         
     self.retrieveList = function() {
-        self.listItems = JSON.parse(localStorage.getItem(self.localStorageKey));
+        // Returns true if the list successfully loaded, otherwise false
+        var item = localStorage.getItem(self.localStorageKey);
+        if (item === undefined) {
+            return false;
+        }
+        self.listItems = JSON.parse(item);
+        return true;
         };
 
 };

--- a/app.js
+++ b/app.js
@@ -23,7 +23,6 @@ $(document).ready(function() {
     $('#button').click(function(){
         var toAdd = $('#checkListEntry').val();
         todoList.addToList(toAdd);
-        todoList.storeList();
         todoList.generateListDiv($('#list'));
         $('#checkListEntry').val('');
     })
@@ -33,7 +32,6 @@ $(document).ready(function() {
        // var toRemove = $('#list').index(this);
        // console.log(toRemove);
         todoList.removeFromList(this.innerHTML);
-        todoList.storeList();
         todoList.generateListDiv($('#list'));
       
         


### PR DESCRIPTION
This lets us safely put all the calls to "storeList" inside of the other calls so we never forget to update the list in localStorage when we make changes to it with `addToList`, etc.

Without each list object having its own key it's not safe because the lists will overwrite each other if you have more than one. 
